### PR TITLE
添加clearsAfterDetached控制onDetachedFromWindow是否clear(), SVGADrawable.kt SVGAImageView.kt SVGAVideoEntity.kt 公开clear()方法.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
+apply from: '../gradle-mvn-push.gradle'
 
 android {
     compileSdkVersion 28
@@ -30,6 +31,7 @@ android {
         exclude 'META-INF/MANIFEST.MF'
     }
 }
+
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')

--- a/library/src/main/java/com/opensource/svgaplayer/SVGACache.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGACache.kt
@@ -1,0 +1,63 @@
+package com.opensource.svgaplayer
+
+import android.content.Context
+import java.io.File
+import java.net.URL
+import java.security.MessageDigest
+
+
+object SVGACache {
+    enum class Type {
+        DEFAULT,
+        FILE
+    }
+
+    private var type: Type = Type.DEFAULT
+    private var cacheDir: String = "/"
+
+    fun onCreate(context: Context?) {
+        onCreate(context, Type.DEFAULT)
+    }
+
+    fun onCreate(context: Context?, type: Type) {
+        if (isInitialized()) return
+        context ?: return
+        cacheDir = "${context.cacheDir.absolutePath}/svga/"
+        File(cacheDir).takeIf { !it.exists() }?.mkdir()
+        this.type = type
+    }
+
+    fun isInitialized(): Boolean {
+        return "/" != cacheDir
+    }
+
+    fun isDefaultCache(): Boolean = type == Type.DEFAULT
+
+    fun isCached(cacheKey: String): Boolean {
+        return (if (isDefaultCache()) buildCacheDir(cacheKey) else buildCacheFile(
+            cacheKey
+        )).exists()
+    }
+
+    fun buildCacheKey(str: String): String {
+        val messageDigest = MessageDigest.getInstance("MD5")
+        messageDigest.update(str.toByteArray(charset("UTF-8")))
+        val digest = messageDigest.digest()
+        var sb = ""
+        for (b in digest) {
+            sb += String.format("%02x", b)
+        }
+        return sb
+    }
+
+    fun buildCacheKey(url: URL): String = buildCacheKey(url.toString())
+
+    fun buildCacheDir(cacheKey: String): File {
+        return File("$cacheDir$cacheKey/")
+    }
+
+    fun buildCacheFile(cacheKey: String): File {
+        return File("$cacheDir$cacheKey.svga")
+    }
+
+}

--- a/library/src/main/java/com/opensource/svgaplayer/SVGACache.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGACache.kt
@@ -27,6 +27,12 @@ object SVGACache {
         this.type = type
     }
 
+//    fun clearCache(context: Context?){
+//        context ?: return
+//        cacheDir = "${context.cacheDir.absolutePath}/svga/"
+//        File(cacheDir).takeIf { it.exists() }?.delete()
+//    }
+
     fun isInitialized(): Boolean {
         return "/" != cacheDir
     }
@@ -34,8 +40,8 @@ object SVGACache {
     fun isDefaultCache(): Boolean = type == Type.DEFAULT
 
     fun isCached(cacheKey: String): Boolean {
-        return (if (isDefaultCache()) buildCacheDir(cacheKey) else buildCacheFile(
-            cacheKey
+        return (if (isDefaultCache()) buildCacheDir(cacheKey) else buildSvgaFile(
+                cacheKey
         )).exists()
     }
 
@@ -56,8 +62,12 @@ object SVGACache {
         return File("$cacheDir$cacheKey/")
     }
 
-    fun buildCacheFile(cacheKey: String): File {
+    fun buildSvgaFile(cacheKey: String): File {
         return File("$cacheDir$cacheKey.svga")
+    }
+
+    fun buildAudioFile(audio: String): File {
+        return File("$cacheDir$audio.mp3")
     }
 
 }

--- a/library/src/main/java/com/opensource/svgaplayer/SVGADrawable.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGADrawable.kt
@@ -54,7 +54,31 @@ class SVGADrawable(val videoItem: SVGAVideoEntity, val dynamicItem: SVGADynamicE
 
     }
 
-    internal fun clear() {
+    fun resume() {
+        videoItem.audioList.forEach { audio ->
+            audio.playID?.let {
+                videoItem.soundPool?.resume(it)
+            }
+        }
+    }
+
+    fun pause() {
+        videoItem.audioList.forEach { audio ->
+            audio.playID?.let {
+                videoItem.soundPool?.pause(it)
+            }
+        }
+    }
+
+    fun stop() {
+        videoItem.audioList.forEach { audio ->
+            audio.playID?.let {
+                videoItem.soundPool?.stop(it)
+            }
+        }
+    }
+
+    fun clear() {
         videoItem.audioList.forEach { audio ->
             audio.playID?.let {
                 videoItem.soundPool?.stop(it)

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAImageView.kt
@@ -34,6 +34,7 @@ open class SVGAImageView @JvmOverloads constructor(context: Context, attrs: Attr
 
     var loops = 0
     var clearsAfterStop = true
+    var clearsAfterDetached = true
     var fillMode: FillMode = FillMode.Forward
     var callback: SVGACallback? = null
 
@@ -187,7 +188,7 @@ open class SVGAImageView @JvmOverloads constructor(context: Context, attrs: Attr
         callback?.onFinished()
     }
 
-    private fun clear() {
+    fun clear() {
         getSVGADrawable()?.cleared = true
         getSVGADrawable()?.clear()
         // 清除对 drawable 的引用
@@ -270,7 +271,9 @@ open class SVGAImageView @JvmOverloads constructor(context: Context, attrs: Attr
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         stopAnimation(true)
-        clear()
+        if (clearsAfterDetached) {
+            clear()
+        }
     }
 
     private class AnimatorListener(view: SVGAImageView) : Animator.AnimatorListener {

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
@@ -200,12 +200,12 @@ class SVGAVideoEntity {
             // 除数不能为 0
             return item
         }
-        audiosFileMap[audio.audioKey]?.let {
-            val fis = FileInputStream(it)
-            val length = fis.available().toDouble()
-            val offset = ((startTime / totalTime) * length).toLong()
-            item.soundID = soundPool?.load(fis.fd, offset, length.toLong(), 1)
-            fis.close()
+        audiosFileMap[audio.audioKey]?.let { file ->
+            FileInputStream(file).use {
+                val length = it.available().toDouble()
+                val offset = ((startTime / totalTime) * length).toLong()
+                item.soundID = soundPool?.load(it.fd, offset, length.toLong(), 1)
+            }
         }
         return item
     }
@@ -221,7 +221,7 @@ class SVGAVideoEntity {
         val audiosFileMap = HashMap<String, File>()
         if (audiosDataMap.count() > 0) {
             audiosDataMap.forEach {
-                val audioCache = File(it.key + ".mp3")
+                val audioCache = SVGACache.buildAudioFile(it.key)
                 audiosFileMap[it.key] =
                     audioCache.takeIf { file -> file.exists() } ?: generateAudioFile(
                         audioCache,

--- a/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
+++ b/library/src/main/java/com/opensource/svgaplayer/SVGAVideoEntity.kt
@@ -210,17 +210,23 @@ class SVGAVideoEntity {
         return item
     }
 
+    private fun generateAudioFile(audioCache: File, value: ByteArray): File {
+        audioCache.createNewFile()
+        FileOutputStream(audioCache).write(value)
+        return audioCache
+    }
+
     private fun generateAudioFileMap(entity: MovieEntity): HashMap<String, File> {
         val audiosDataMap = generateAudioMap(entity)
         val audiosFileMap = HashMap<String, File>()
         if (audiosDataMap.count() > 0) {
             audiosDataMap.forEach {
-                val tmpFile = File.createTempFile(it.key + "_tmp", ".mp3")
-                val fos = FileOutputStream(tmpFile)
-                fos.write(it.value)
-                fos.flush()
-                fos.close()
-                audiosFileMap[it.key] = tmpFile
+                val audioCache = File(it.key + ".mp3")
+                audiosFileMap[it.key] =
+                    audioCache.takeIf { file -> file.exists() } ?: generateAudioFile(
+                        audioCache,
+                        it.value
+                    )
             }
         }
         return audiosFileMap
@@ -264,7 +270,7 @@ class SVGAVideoEntity {
         SoundPool(12.coerceAtMost(entity.audios.count()), AudioManager.STREAM_MUSIC, 0)
     }
 
-    internal fun clear() {
+    fun clear() {
         soundPool?.release()
         soundPool = null
         audioList = emptyList()


### PR DESCRIPTION
1 SVGAParser.kt 添加缓存SVGA文件到本地的扩展[SVGACache.kt]   
  调用示例:在Application.onCreate()里面,SVGACache.onCreate(this,SVGACache.Type.File)即会在decodeFromURL
  里面自动处理缓存逻辑
2 SVGADrawable.kt SVGAImageView.kt SVGAVideoEntity.kt 公开clear()方法.
3 SVGAImageView.kt 添加clearsAfterDetached,默认true,不影响原来功能呢,用于控制imageview在onDetach的时候是否
  要自动调用clear().暂时为需要给RecyclerView缓存drawable或者entity的人士提供临时解决方案.用完记得调用clear()!!!!!!!
4 SVGAVideoEntity.kt generateAudioFileMap 方法每次打开同一个文件会解压一次mp3.缓存文件夹会越来越大.改为固定名字.
5 SVGAVideoEntity.kt 里面soundPool如果解析时load同一个svga的声音文件会出现无回调的情况,导致这里的callback不执行,
  原因暂时未知.目前解决方案是公开imageview,drawable,entity的clear(),然后在播放带声音的svgaimageview处,
  把解析完的drawable或者entity缓存下来,下次直接播放.用完再调用clear()!!!!!!!没有声音的不存在此问题.
  (真实场景如下:持续以队列形式播放同一个带声音的svga,由于2.5.8自动clear(),且clear()相关方法没有公开,
  只能一直重新decodeFromURL同一个远程svga文件,会导致onComplete与onError不回调)